### PR TITLE
PLATUI-2346: Create ui-test-runner helper library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib_managed
 tmp
 .history
 dist
+/.bsp
 /.idea
 /*.iml
 /*.ipr

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,23 @@
+version = 3.7.3
+maxColumn = 120
+binPack.parentConstructors = false
+indent.callSite = 2
+indent.defnSite = 2
+align.preset = most
+align.tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "shouldEqual", "shouldNot", "must" ]
+align.arrowEnumeratorGenerator = true
+align.openParenCallSite = false
+align.openParenDefnSite = false
+spaces.beforeContextBoundColon = Never
+spaces.inImportCurlyBraces = false
+lineEndings = unix
+rewrite.rules = [RedundantBraces, RedundantParens, Imports]
+rewrite.redundantBraces.includeUnitMethods = true
+rewrite.redundantBraces.stringInterpolation = true
+rewrite.redundantBraces.maxBreaks = 100
+rewrite.imports.sort = ascii
+newlines.sometimesBeforeColonInMethodReturnType = true
+newlines.penalizeSingleSelectMultiArgList = false
+runner.dialect = scala213
+importSelectors = singleLine
+project.git = true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A helper library for UI testing at HMRC.
 
 ## Development
 
+### Tests
+
+Run tests as follows:
+
+```bash
+sbt clean test
+```
+
 ### Scalafmt
 
 Check all project files are formatted as expected as follows:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
-
 # ui-test-runner
 
-This is a placeholder README.md for a new repository
+A helper library for UI testing at HMRC.
 
-### License
+## Development
+
+### Scalafmt
+
+Check all project files are formatted as expected as follows:
+
+```bash
+sbt scalafmtCheckAll scalafmtCheck
+```
+
+Format `*.sbt` and `project/*.scala` files as follows:
+
+```bash
+sbt scalafmtSbt
+```
+
+Format all project files as follows:
+
+```bash
+sbt scalafmtAll
+```
+
+## License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,8 @@
+lazy val library = (project in file("."))
+  .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
+  .settings(
+    name := "ui-test-runner",
+    version := "0.1.0",
+    scalaVersion := "2.13.8",
+    libraryDependencies ++= Dependencies.compile
+  )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,14 @@
+import sbt._
+
+object Dependencies {
+
+  val compile: Seq[ModuleID] = Seq(
+    "com.typesafe"                % "config"        % "1.4.2",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+    "com.vladsch.flexmark"        % "flexmark-all"  % "0.62.2",
+    "org.scalatest"              %% "scalatest"     % "3.2.16",
+    "org.seleniumhq.selenium"     % "selenium-java" % "4.9.1",
+    "org.slf4j"                   % "slf4j-simple"  % "1.7.36"
+  )
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,8 @@
+resolvers += "HMRC-open-artefacts-maven2" at "https://open.artefacts.tax.service.gov.uk/maven2"
+resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
+  Resolver.ivyStylePatterns
+)
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/src/main/scala/uk/gov/hmrc/configuration/TestEnvironment.scala
+++ b/src/main/scala/uk/gov/hmrc/configuration/TestEnvironment.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.configuration
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+object TestEnvironment {
+
+  private def configuration: Config            = ConfigFactory.load()
+  private def environment: String              = configuration.getString("environment")
+  private def defaultConfiguration: Config     = configuration.getConfig("local")
+  private def environmentConfiguration: Config = configuration.getConfig(environment).withFallback(defaultConfiguration)
+
+  def url(service: String): String = {
+    val host = environment match {
+      case "local" => s"$serviceHost:${servicePort(service)}"
+      case _       => s"${environmentConfiguration.getString("services.host")}"
+    }
+
+    s"$host${serviceRoute(service)}"
+  }
+
+  private def serviceHost: String = environmentConfiguration.getString("services.host")
+
+  private def servicePort(service: String): String = environmentConfiguration.getString(s"services.$service.port")
+
+  private def serviceRoute(service: String): String =
+    environmentConfiguration.getString(s"services.$service.productionRoute")
+
+}

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/Browser.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/Browser.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import org.openqa.selenium.MutableCapabilities
+
+import java.time.Duration
+
+trait Browser {
+
+  protected def startBrowser(capabilities: Option[MutableCapabilities] = None): Unit = {
+    Driver.instance = new DriverFactory().initialise(capabilities)
+    Driver.instance.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(3))
+    Driver.instance.manage().window().maximize()
+  }
+
+  protected def quitBrowser(): Unit =
+    if (Driver.instance != null)
+      Driver.instance.quit()
+
+}

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/Driver.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/Driver.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import org.openqa.selenium.remote.RemoteWebDriver
+
+object Driver {
+
+  implicit var instance: RemoteWebDriver = _
+
+}

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import com.typesafe.scalalogging.LazyLogging
+import org.openqa.selenium.MutableCapabilities
+import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.edge.EdgeOptions
+import org.openqa.selenium.firefox.FirefoxOptions
+import org.openqa.selenium.remote.RemoteWebDriver
+
+import java.net.URL
+
+class DriverFactory extends LazyLogging {
+
+  def initialise(capabilities: Option[MutableCapabilities] = None): RemoteWebDriver = {
+    val browser = sys.props.get("browser").map(_.toLowerCase)
+
+    browser match {
+      case Some("chrome")  => remoteWebDriver(chromeOptions(capabilities))
+      case Some("edge")    => remoteWebDriver(edgeOptions(capabilities))
+      case Some("firefox") => remoteWebDriver(firefoxOptions(capabilities))
+      case Some(browser)   => throw DriverFactoryException(s"Browser '$browser' is not supported.")
+      case None            => throw DriverFactoryException("System property 'browser' is required but was not defined.")
+    }
+  }
+
+  private[webdriver] def chromeOptions(capabilities: Option[MutableCapabilities]): ChromeOptions = {
+    var options: ChromeOptions = new ChromeOptions
+
+    capabilities match {
+      case Some(value) =>
+        options = options.merge(value)
+        options
+      case None        =>
+        options
+    }
+  }
+
+  private[webdriver] def edgeOptions(capabilities: Option[MutableCapabilities]): EdgeOptions = {
+    var options: EdgeOptions = new EdgeOptions
+
+    capabilities match {
+      case Some(value) =>
+        options = options.merge(value)
+        options
+      case None        =>
+        options
+    }
+  }
+
+  private[webdriver] def firefoxOptions(capabilities: Option[MutableCapabilities]): FirefoxOptions = {
+    var options: FirefoxOptions = new FirefoxOptions
+
+    capabilities match {
+      case Some(value) =>
+        options = options.merge(value)
+        options
+      case None        =>
+        options
+    }
+  }
+
+  private def remoteWebDriver(capabilities: MutableCapabilities): RemoteWebDriver = {
+    val remoteAddress: String   = "http://localhost:4444"
+    val driver: RemoteWebDriver = new RemoteWebDriver(new URL(remoteAddress), capabilities)
+
+    logger.info(s"Browser: ${driver.getCapabilities.getBrowserName} ${driver.getCapabilities.getBrowserVersion}")
+    driver
+  }
+
+}
+
+private case class DriverFactoryException(exception: String) extends RuntimeException(exception)

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/ScreenshotOnFailure.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/ScreenshotOnFailure.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import org.openqa.selenium.io.FileHandler.{copy, createDir}
+import org.openqa.selenium.{OutputType, TakesScreenshot}
+import org.scalatest.{Documenting, Outcome, TestSuite, TestSuiteMixin}
+
+import java.io.File
+
+trait ScreenshotOnFailure extends TestSuiteMixin with Documenting { this: TestSuite =>
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    val testOutcome         = super.withFixture(test)
+    val testName            = test.name.replaceAll(" ", "-").replaceAll(":", "")
+    val screenshotName      = testName + ".png"
+    val screenshotDirectory = "./target/test-reports/html-report/images/screenshots/"
+
+    if (testOutcome.isExceptional) {
+      captureScreenshot(screenshotName, screenshotDirectory)
+      markup(s"<img src='images/screenshots/$screenshotName' />")
+    }
+
+    testOutcome
+  }
+
+  private def captureScreenshot(screenshotName: String, screenshotDirectory: String): Unit = {
+    val tmpFile        = Driver.instance.asInstanceOf[TakesScreenshot].getScreenshotAs(OutputType.FILE)
+    val screenshotFile = new File(screenshotDirectory, screenshotName)
+
+    createDir(new File(screenshotDirectory))
+    copy(tmpFile, screenshotFile)
+  }
+
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,52 @@
+# Copyright 2023 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+environment: local
+
+local {
+  services {
+    host: "http://localhost"
+    service-frontend {
+      port: 1234
+      productionRoute: "/test"
+    }
+  }
+}
+
+dev {
+  services {
+    host: "https://www.development.tax.service.gov.uk"
+    service-frontend {
+      productionRoute: "/test"
+    }
+  }
+}
+
+qa {
+  services {
+    host: "https://www.qa.tax.service.gov.uk"
+    service-frontend {
+      productionRoute: "/test"
+    }
+  }
+}
+
+staging {
+  services {
+    host: "https://www.staging.tax.service.gov.uk"
+    service-frontend {
+      productionRoute: "/test"
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/configuration/TestEnvironmentSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/configuration/TestEnvironmentSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.configuration
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TestEnvironmentSpec extends AnyWordSpec with Matchers {
+
+  "TestEnvironment" should {
+
+    "return local url" in {
+      val url = TestEnvironment.url("service-frontend") + "/local"
+
+      url shouldBe "http://localhost:1234/test/local"
+    }
+
+    "return dev url" in {
+      System.setProperty("environment", "dev")
+      ConfigFactory.invalidateCaches()
+
+      val url: String = TestEnvironment.url("service-frontend") + "/dev"
+
+      url shouldBe "https://www.development.tax.service.gov.uk/test/dev"
+    }
+
+    "return qa url" in {
+      System.setProperty("environment", "qa")
+      ConfigFactory.invalidateCaches()
+
+      val url: String = TestEnvironment.url("service-frontend") + "/qa"
+
+      url shouldBe "https://www.qa.tax.service.gov.uk/test/qa"
+    }
+
+    "return staging url" in {
+      System.setProperty("environment", "staging")
+      ConfigFactory.invalidateCaches()
+
+      val url: String = TestEnvironment.url("service-frontend") + "/staging"
+
+      url shouldBe "https://www.staging.tax.service.gov.uk/test/staging"
+    }
+
+    "throw an exception for unknown environment" in {
+      System.setProperty("environment", "test")
+      ConfigFactory.invalidateCaches()
+
+      val exception: Exception = intercept[Exception] {
+        TestEnvironment.url("test-frontend") + "/test"
+      }
+
+      assert(exception.getMessage contains "No configuration setting found for key 'test'")
+    }
+
+    "throw an exception for unknown service" in {
+      System.setProperty("environment", "local")
+      ConfigFactory.invalidateCaches()
+
+      val exception: Exception = intercept[Exception] {
+        TestEnvironment.url("test-frontend") + "/test"
+      }
+
+      assert(exception.getMessage contains "No configuration setting found for key 'services.test-frontend'")
+    }
+
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/selenium/webdriver/BrowserSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/selenium/webdriver/BrowserSpec.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import org.openqa.selenium.chrome.ChromeOptions
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BrowserSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with Browser {
+
+  override def afterEach(): Unit =
+    quitBrowser()
+
+  "Browser" should {
+
+    "start Chrome browser with default options" in {
+      System.setProperty("browser", "chrome")
+
+      startBrowser()
+
+      Driver.instance.getSessionId                  shouldNot be(null)
+      Driver.instance.getCapabilities.getBrowserName shouldBe "chrome"
+    }
+
+    "start Chrome browser with custom options" in {
+      System.setProperty("browser", "chrome")
+
+      val capabilities = new ChromeOptions
+      capabilities.setAcceptInsecureCerts(true)
+      startBrowser(Some(capabilities))
+
+      Driver.instance.getSessionId                                      shouldNot be(null)
+      Driver.instance.getCapabilities.getBrowserName                     shouldBe "chrome"
+      Driver.instance.getCapabilities.asMap().get("acceptInsecureCerts") shouldBe true
+    }
+
+    "quit Chrome browser" in {
+      System.setProperty("browser", "chrome")
+
+      startBrowser()
+
+      Driver.instance.getSessionId                  shouldNot be(null)
+      Driver.instance.getCapabilities.getBrowserName shouldBe "chrome"
+
+      quitBrowser()
+
+      Driver.instance.getSessionId shouldBe null
+    }
+
+    "throw an exception for unknown browser" in {
+      System.setProperty("browser", "test")
+
+      val exception: Exception = intercept[Exception] {
+        startBrowser()
+      }
+
+      exception.getMessage shouldBe "Browser 'test' is not supported."
+    }
+
+    "throw an exception for undefined browser" in {
+      System.clearProperty("browser")
+
+      val exception: Exception = intercept[Exception] {
+        startBrowser()
+      }
+
+      exception.getMessage shouldBe "System property 'browser' is required but was not defined."
+    }
+
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/selenium/webdriver/DriverFactorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/selenium/webdriver/DriverFactorySpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.edge.EdgeOptions
+import org.openqa.selenium.firefox.FirefoxOptions
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DriverFactorySpec extends AnyWordSpec with Matchers {
+
+  trait Setup {
+    val driverFactory: DriverFactory = new DriverFactory
+  }
+
+  "DriverFactory" should {
+
+    "return default Chrome options" in new Setup {
+      val options: ChromeOptions = driverFactory.chromeOptions(None)
+
+      options.asMap().get("browserName") shouldBe "chrome"
+      options
+        .asMap()
+        .get("goog:chromeOptions")
+        .toString                        shouldBe "{args=[--remote-allow-origins=*], extensions=[]}"
+    }
+
+    "return merged Chrome options" in new Setup {
+      val capabilities = new ChromeOptions
+
+      capabilities.setAcceptInsecureCerts(true)
+      capabilities.addArguments("--headless=new")
+
+      val options: ChromeOptions = driverFactory.chromeOptions(Some(capabilities))
+
+      options.asMap().get("acceptInsecureCerts") shouldBe true
+      options.asMap().get("browserName")         shouldBe "chrome"
+      options
+        .asMap()
+        .get("goog:chromeOptions")
+        .toString                                shouldBe "{args=[--remote-allow-origins=*, --headless=new], extensions=[]}"
+    }
+
+    "return default Edge options" in new Setup {
+      val options: EdgeOptions = driverFactory.edgeOptions(None)
+
+      options.asMap().get("browserName") shouldBe "MicrosoftEdge"
+      options
+        .asMap()
+        .get("ms:edgeOptions")
+        .toString                        shouldBe "{args=[--remote-allow-origins=*], extensions=[]}"
+    }
+
+    "return merged Edge options" in new Setup {
+      val capabilities = new EdgeOptions
+
+      capabilities.setAcceptInsecureCerts(true)
+      capabilities.addArguments("--headless=new")
+
+      val options: EdgeOptions = driverFactory.edgeOptions(Some(capabilities))
+
+      options.asMap().get("acceptInsecureCerts") shouldBe true
+      options.asMap().get("browserName")         shouldBe "MicrosoftEdge"
+      options
+        .asMap()
+        .get("ms:edgeOptions")
+        .toString                                shouldBe "{args=[--remote-allow-origins=*, --headless=new], extensions=[]}"
+    }
+
+    "return default Firefox options" in new Setup {
+      val options: FirefoxOptions = driverFactory.firefoxOptions(None)
+
+      options.asMap().get("browserName")                 shouldBe "firefox"
+      options.asMap().get("moz:firefoxOptions").toString shouldBe "{}"
+    }
+
+    "return merged Firefox options" in new Setup {
+      val capabilities = new FirefoxOptions
+
+      capabilities.setAcceptInsecureCerts(true)
+      capabilities.addArguments("-headless")
+
+      val options: FirefoxOptions = driverFactory.firefoxOptions(Some(capabilities))
+
+      options.asMap().get("acceptInsecureCerts")         shouldBe true
+      options.asMap().get("browserName")                 shouldBe "firefox"
+      options.asMap().get("moz:firefoxOptions").toString shouldBe "{args=[-headless]}"
+    }
+
+  }
+
+}


### PR DESCRIPTION
We (@tmc-ee and @vivrichards600) have created the ui-test-runner helper library in order to make and test changes to our helper library without impacting teams.

- [Add project structure and dependencies](https://github.com/hmrc/ui-test-runner/commit/a0f29df42acb6d34dd223bcd3f7a6e7d49f09d90)
- [Add test environment configuration](https://github.com/hmrc/ui-test-runner/commit/dd55af61ecbbdc6a152fd7ce3aa355bbac4ada3c)
- [Add selenium webdriver configuration](https://github.com/hmrc/ui-test-runner/commit/ae6b074a387310f61efebc042ef332174b4fa25c)
- [Add screenshot capture on test exception](https://github.com/hmrc/ui-test-runner/commit/b28316f3358c7a5f2ae36b00d5c895d6e9f83d6a)