### PR TITLE
PLATUI-BAU: Update dependencies and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val library = (project in file("."))
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     name := "ui-test-runner",
-    version := "0.8.0",
+    version := "0.9.0",
     scalaVersion := "2.13.8",
     libraryDependencies ++= Dependencies.compile
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
     "com.typesafe.play"          %% "play-json"     % "2.9.4",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "com.vladsch.flexmark"        % "flexmark-all"  % "0.62.2",
-    "org.scalatest"              %% "scalatest"     % "3.2.16",
-    "org.seleniumhq.selenium"     % "selenium-java" % "4.11.0",
+    "org.scalatest"              %% "scalatest"     % "3.2.17",
+    "org.seleniumhq.selenium"     % "selenium-java" % "4.13.0",
     "org.slf4j"                   % "slf4j-simple"  % "1.7.36"
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,8 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")


### PR DESCRIPTION
Update project version to 0.9.0

Dependencies
- Update `scalatest` to version `3.2.17`
- Update `selenium-java` to version `4.13.0`

Plugins
- Update `sbt-auto-build` to version `3.14.0`
- Update `sbt-scalafmt` to version `2.5.2`