### PR TITLE
PLATUI-2836: Allow insecure certificates by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val library = (project in file("."))
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     name := "ui-test-runner",
-    version := "0.16.0",
+    version := "0.17.0",
     scalaVersion := "2.13.12",
     libraryDependencies ++= Dependencies.compile
   )

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
@@ -47,6 +47,7 @@ class DriverFactory extends LazyLogging {
       Source.fromResource(s"extensions/chrome/accessibility-assessment").getLines().mkString
 
     options.addEncodedExtensions(accessibilityAssessmentExtension)
+    options.setAcceptInsecureCerts(true)
     options.setCapability("se:downloadsEnabled", true)
     securityAssessment(options)
     options
@@ -58,6 +59,7 @@ class DriverFactory extends LazyLogging {
       Source.fromResource(s"extensions/edge/accessibility-assessment").getLines().mkString
 
     options.addEncodedExtensions(accessibilityAssessmentExtension)
+    options.setAcceptInsecureCerts(true)
     options.setCapability("se:downloadsEnabled", true)
     securityAssessment(options)
     options
@@ -66,6 +68,7 @@ class DriverFactory extends LazyLogging {
   private[webdriver] def firefoxOptions(): FirefoxOptions = {
     val options: FirefoxOptions = new FirefoxOptions
 
+    options.setAcceptInsecureCerts(true)
     options.setCapability("se:downloadsEnabled", true)
     securityAssessment(options)
     options
@@ -99,7 +102,6 @@ class DriverFactory extends LazyLogging {
           capabilities.asInstanceOf[FirefoxOptions].addPreference("network.proxy.allow_hijacking_localhost", true)
       }
 
-      capabilities.setCapability("acceptInsecureCerts", true)
       capabilities.setCapability("proxy", proxy)
       logger.info(s"Security assessment: Running on localhost:11000")
     }

--- a/src/test/scala/uk/gov/hmrc/selenium/webdriver/DriverFactorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/selenium/webdriver/DriverFactorySpec.scala
@@ -38,6 +38,7 @@ class DriverFactorySpec extends AnyWordSpec with Matchers {
         Source.fromResource("extensions/chrome/accessibility-assessment").getLines().mkString
 
       options.asMap().get("browserName")         shouldBe "chrome"
+      options.asMap().get("acceptInsecureCerts") shouldBe true
       options
         .asMap()
         .get("goog:chromeOptions")
@@ -63,6 +64,7 @@ class DriverFactorySpec extends AnyWordSpec with Matchers {
         Source.fromResource("extensions/edge/accessibility-assessment").getLines().mkString
 
       options.asMap().get("browserName")         shouldBe "MicrosoftEdge"
+      options.asMap().get("acceptInsecureCerts") shouldBe true
       options
         .asMap()
         .get("ms:edgeOptions")
@@ -86,6 +88,7 @@ class DriverFactorySpec extends AnyWordSpec with Matchers {
       val options: FirefoxOptions = driverFactory.firefoxOptions()
 
       options.asMap().get("browserName")                 shouldBe "firefox"
+      options.asMap().get("acceptInsecureCerts")         shouldBe true
       options.asMap().get("moz:firefoxOptions").toString shouldBe "{}"
       options.asMap().get("se:downloadsEnabled")         shouldBe true
     }


### PR DESCRIPTION
- [Update browser options to enable setAcceptInsecureCerts true for Chrome, Edge and Firefox](https://github.com/hmrc/ui-test-runner/commit/508e656d29e816e6bbbf5a25b7c620a6da8d82de)
- [Update tests based on changes to browser options](https://github.com/hmrc/ui-test-runner/commit/5826faab73ed6edfb756eed6114a54c60930d888)
- [Update project version to 0.17.0](https://github.com/hmrc/ui-test-runner/commit/cb536b7a072ff97ce2f08b4ab9df3125ed3fa599)