### PR TITLE
PLATUI-BAU: Add waitForInvisibilityOfElementWithText to PageObject component

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val library = (project in file("."))
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     name := "ui-test-runner",
-    version := "0.17.0",
+    version := "0.18.0",
     scalaVersion := "2.13.12",
     libraryDependencies ++= Dependencies.compile
   )

--- a/src/main/scala/uk/gov/hmrc/selenium/component/PageObject.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/component/PageObject.scala
@@ -87,6 +87,9 @@ trait PageObject {
   protected def deselectByVisibleText(locator: By, value: String): Unit =
     withSelect(locator)(_.deselectByVisibleText(value))
 
+  protected def waitForInvisibilityOfElementWithText(locator: By, value: String): Boolean =
+    fluentWait.until(ExpectedConditions.invisibilityOfElementWithText(locator, value))
+
   private def clear(locator: By): Unit = {
     waitForElementToBePresent(locator)
     findElement(locator).clear()


### PR DESCRIPTION
- [Add waitForInvisibilityOfElementWithText to PageObject component](https://github.com/hmrc/ui-test-runner/commit/5c36ccd8fff438c027b5d8c053c46324c5b288d9)
- [Update project version to 0.18.0](https://github.com/hmrc/ui-test-runner/commit/98d8a039f7211eb02e70addf776a5b28042b761b)