### PR TITLE
PLATUI-BAU: Update project dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val library = (project in file("."))
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     name := "ui-test-runner",
-    version := "0.18.0",
+    version := "0.19.0",
     scalaVersion := "2.13.12",
     libraryDependencies ++= Dependencies.compile
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
     "com.vladsch.flexmark"        % "flexmark-all"  % "0.64.8",
     "org.scalatest"              %% "scalatest"     % "3.2.18",
     "org.seleniumhq.selenium"     % "selenium-java" % "4.18.1",
-    "org.slf4j"                   % "slf4j-simple"  % "1.7.36"
+    "org.slf4j"                   % "slf4j-simple"  % "2.0.9"
   )
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "com.vladsch.flexmark"        % "flexmark-all"  % "0.64.8",
     "org.scalatest"              %% "scalatest"     % "3.2.18",
-    "org.seleniumhq.selenium"     % "selenium-java" % "4.16.1",
+    "org.seleniumhq.selenium"     % "selenium-java" % "4.18.1",
     "org.slf4j"                   % "slf4j-simple"  % "1.7.36"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "com.typesafe"                % "config"        % "1.4.3",
-    "com.typesafe.play"          %% "play-json"     % "2.9.4",
+    "com.typesafe.play"          %% "play-json"     % "2.10.4",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "com.vladsch.flexmark"        % "flexmark-all"  % "0.62.2",
     "org.scalatest"              %% "scalatest"     % "3.2.17",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     "com.typesafe"                % "config"        % "1.4.3",
     "com.typesafe.play"          %% "play-json"     % "2.10.4",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "com.vladsch.flexmark"        % "flexmark-all"  % "0.62.2",
+    "com.vladsch.flexmark"        % "flexmark-all"  % "0.64.8",
     "org.scalatest"              %% "scalatest"     % "3.2.18",
     "org.seleniumhq.selenium"     % "selenium-java" % "4.16.1",
     "org.slf4j"                   % "slf4j-simple"  % "1.7.36"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,9 @@
-import sbt._
+import sbt.*
 
 object Dependencies {
 
   val compile: Seq[ModuleID] = Seq(
-    "com.typesafe"                % "config"        % "1.4.2",
+    "com.typesafe"                % "config"        % "1.4.3",
     "com.typesafe.play"          %% "play-json"     % "2.9.4",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "com.vladsch.flexmark"        % "flexmark-all"  % "0.62.2",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     "com.typesafe.play"          %% "play-json"     % "2.10.4",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "com.vladsch.flexmark"        % "flexmark-all"  % "0.62.2",
-    "org.scalatest"              %% "scalatest"     % "3.2.17",
+    "org.scalatest"              %% "scalatest"     % "3.2.18",
     "org.seleniumhq.selenium"     % "selenium-java" % "4.16.1",
     "org.slf4j"                   % "slf4j-simple"  % "1.7.36"
   )

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/Browser.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/Browser.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.selenium.webdriver
 
-import java.time.Duration
 import scala.util.Try
 
 trait Browser extends FileDownload {


### PR DESCRIPTION
- [Update typesafe config version to 1.4.3](https://github.com/hmrc/ui-test-runner/commit/794298f38aa3325f08fbeb822cb76bf967c68eca)
- [Update play-json version to 2.10.4](https://github.com/hmrc/ui-test-runner/commit/a583d1b1a75111932e153d977d55fb4d21c4dd45)
- [Update scalatest version to 3.2.18](https://github.com/hmrc/ui-test-runner/commit/2b6f43ab4fdb81606c5400d1aae0a69c33ae6df6)
- [Update flexmark version to 0.64.8](https://github.com/hmrc/ui-test-runner/commit/22d2893cc4a1aa903947187f81e6d17f4b06613a)
- [Update selenium version to 4.18.1](https://github.com/hmrc/ui-test-runner/commit/d5b87b1fe83515993c01af216cfeb28e85283a73)
- [Update slf4j-simple version to 2.0.9](https://github.com/hmrc/ui-test-runner/commit/0440e464951aef5cddda58f8f7fe2af66292f18f)
- [Update project version to 0.19.0](https://github.com/hmrc/ui-test-runner/commit/185af65398a03a36cadcfa0a5758895883b4e964)