### PR TITLE
PLATUI-2886: Replace slf4j-simple with logback-classic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,6 @@ lazy val library = (project in file("."))
   .settings(
     name := "ui-test-runner",
     version := "0.19.0",
-    scalaVersion := "2.13.12",
+    scalaVersion := "2.13.13",
     libraryDependencies ++= Dependencies.compile
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val library = (project in file("."))
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(
     name := "ui-test-runner",
-    version := "0.19.0",
+    version := "0.20.0",
     scalaVersion := "2.13.13",
     libraryDependencies ++= Dependencies.compile
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,13 +3,13 @@ import sbt.*
 object Dependencies {
 
   val compile: Seq[ModuleID] = Seq(
-    "com.typesafe"                % "config"        % "1.4.3",
-    "com.typesafe.play"          %% "play-json"     % "2.10.4",
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-    "com.vladsch.flexmark"        % "flexmark-all"  % "0.64.8",
-    "org.scalatest"              %% "scalatest"     % "3.2.18",
-    "org.seleniumhq.selenium"     % "selenium-java" % "4.18.1",
-    "org.slf4j"                   % "slf4j-simple"  % "2.0.9"
+    "ch.qos.logback"              % "logback-classic" % "1.5.1",
+    "com.typesafe"                % "config"          % "1.4.3",
+    "com.typesafe.play"          %% "play-json"       % "2.10.4",
+    "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5",
+    "com.vladsch.flexmark"        % "flexmark-all"    % "0.64.8",
+    "org.scalatest"              %% "scalatest"       % "3.2.18",
+    "org.seleniumhq.selenium"     % "selenium-java"   % "4.18.1"
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "HMRC-open-artefacts-maven2" at "https://open.artefacts.tax.service.gov.uk/maven2"
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns
 )
@@ -7,4 +7,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.4")


### PR DESCRIPTION
- [Replace slf4j-simple with logback-classic version 1.5.1](https://github.com/hmrc/ui-test-runner/commit/661aa04111972822ca4f7049e7976d0b66f894af)
- [Update sbt-updates version to 0.6.4](https://github.com/hmrc/ui-test-runner/commit/f7c2f7ab85e90ec724d9a9eeae67d18bdc06e523)
- [Update scala version to 2.13.13](https://github.com/hmrc/ui-test-runner/commit/c10b2f46f060a10069b46bff080e46cb420b8b63)
- [Update project version to 0.20.0](https://github.com/hmrc/ui-test-runner/commit/37b60ace0315e792d8d81d4c0c9c85e64b96f0a5)