### PR TITLE
PLATUI-BAU - Bump browsers to 126

### DIFF
--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
@@ -31,9 +31,9 @@ import scala.jdk.CollectionConverters.MapHasAsJava
 
 class DriverFactory extends LazyLogging {
 
-  private val edgeBrowserVersion    = sys.env.getOrElse("BROWSER_VERSION", "125")
-  private val firefoxBrowserVersion = sys.env.getOrElse("BROWSER_VERSION", "125")
-  private val chromeBrowserVersion  = sys.env.getOrElse("BROWSER_VERSION", "125")
+  private val edgeBrowserVersion    = sys.env.getOrElse("BROWSER_VERSION", "126")
+  private val firefoxBrowserVersion = sys.env.getOrElse("BROWSER_VERSION", "126")
+  private val chromeBrowserVersion  = sys.env.getOrElse("BROWSER_VERSION", "126")
 
   def initialise(): WebDriver = {
     val browser = sys.props.get("browser").map(_.toLowerCase)


### PR DESCRIPTION
Releasing Chrome, Firefox and Edge versions 126