### PR TITLE
PLATUI-3442 - Introduce Selenium BiDi support for supported browsers.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,3 +24,5 @@ security.assessment = ${?SECURITY_ASSESSMENT}
 
 zap.host = "localhost:11000"
 zap.host = ${?ZAP_HOST}
+
+bidi = false

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
@@ -52,6 +52,7 @@ class DriverFactory extends LazyLogging {
     logger.info(s"Browser: ${options.getBrowserName} ${options.getBrowserVersion}")
 
     browserLogging(options)
+    enableBiDi(options)
     accessibilityAssessment(options)
     securityAssessment(options)
     downloadDirectory(options)
@@ -73,6 +74,7 @@ class DriverFactory extends LazyLogging {
     logger.info(s"Browser: ${options.getBrowserName} ${options.getBrowserVersion}")
 
     browserLogging(options)
+    enableBiDi(options)
     accessibilityAssessment(options)
     securityAssessment(options)
     downloadDirectory(options)
@@ -136,6 +138,32 @@ class DriverFactory extends LazyLogging {
         case _               =>
           logger.warn("Accessibility assessment: Not available for Firefox")
       }
+
+    capabilities
+  }
+
+  private def enableBiDi(capabilities: MutableCapabilities): MutableCapabilities = {
+    if (!TestRunnerConfig.biDiEnabled) {
+      logger.info("BiDi not enabled via config.")
+      return capabilities
+    }
+
+    val browser = capabilities.getBrowserName.toLowerCase
+
+    browser match {
+      case "chrome" | "msedge" | "microsoftedge" =>
+        // enables the WebSocket connection for bidirectional communication
+        // https://www.selenium.dev/documentation/webdriver/bidi/
+        capabilities.setCapability("webSocketUrl", true)
+        logger.info(s"BiDi enabled for $browser (webSocketUrl=true).")
+
+      case "firefox" =>
+        logger.warn("BiDi is not currently supported for Firefox in this setup. Skipping capability.")
+
+      case other =>
+        logger.warn(s"BiDi support not implemented for browser: '$other'. Skipping capability.")
+    }
+    logger.debug(s"Capabilities after BiDi config: ${capabilities.asMap()}")
 
     capabilities
   }

--- a/src/main/scala/uk/gov/hmrc/uitestrunner/config/TestRunnerConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/uitestrunner/config/TestRunnerConfig.scala
@@ -42,6 +42,9 @@ object TestRunnerConfig {
       .Try(configuration.getDuration("accessibility.timeout").toScala)
       .getOrElse(configuration.getInt("accessibility.timeout").millis)
 
+  def biDiEnabled: Boolean =
+    configuration.getBoolean("bidi")
+
   // Since there is a system property "browser" which is a String
   // this is incompatible with HOCON where browser.logger etc mean browser is an Object
   // For now stick with system properties only

--- a/src/test/scala/uk/gov/hmrc/selenium/webdriver/DriverFactorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/selenium/webdriver/DriverFactorySpec.scala
@@ -122,6 +122,26 @@ class DriverFactorySpec extends AnyWordSpec with Matchers with BeforeAndAfterEac
         .toString                                shouldBe s"{args=[--disable-search-engine-choice-screen, --disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,OptimizationHints, --disable-features=MediaRouter], extensions=[$accessibilityAssessmentExtension], prefs={download.default_directory=$downloadDirectory}}"
     }
 
+    "set BiDi capability when enabled in config for Chrome" in new Setup {
+      System.setProperty("bidi", "true")
+      ConfigFactory.invalidateCaches()
+
+      val options: ChromeOptions = driverFactory.chromeOptions()
+
+      // Chrome: BiDi uses webSocketUrl = true
+      options.asMap().get("webSocketUrl") shouldBe true
+    }
+
+    "not set BiDi capability when disabled in config for Chrome" in new Setup {
+      System.setProperty("bidi", "false")
+      ConfigFactory.invalidateCaches()
+
+      val options: ChromeOptions = driverFactory.chromeOptions()
+
+      // Should not include BiDi capability
+      Option(options.asMap().get("webSocketUrl")) shouldBe None
+    }
+
     "return default Edge options" in new Setup {
       val options: EdgeOptions = driverFactory.edgeOptions()
 
@@ -174,6 +194,26 @@ class DriverFactorySpec extends AnyWordSpec with Matchers with BeforeAndAfterEac
         .asMap()
         .get("ms:edgeOptions")
         .toString                                shouldBe s"{args=[], extensions=[$accessibilityAssessmentExtension], prefs={download.default_directory=$downloadDirectory}}"
+    }
+
+    "set BiDi capability when enabled in config for Edge" in new Setup {
+      System.setProperty("bidi", "true")
+      ConfigFactory.invalidateCaches()
+
+      val options: EdgeOptions = driverFactory.edgeOptions()
+
+      // Edge: BiDi uses webSocketUrl = true
+      options.asMap().get("webSocketUrl") shouldBe true
+    }
+
+    "not set BiDi capability for Firefox regardless of config" in new Setup {
+      System.setProperty("bidi", "true")
+      ConfigFactory.invalidateCaches()
+
+      val options: FirefoxOptions = driverFactory.firefoxOptions()
+
+      // Firefox should not get webSocketUrl at all
+      Option(options.asMap().get("webSocketUrl")) shouldBe None
     }
 
     "return default Firefox options" in new Setup {


### PR DESCRIPTION
- Adds Bidi support for Chrome and Edge.
- Firefox is still not fully supported

Further information on Selenium BiDi https://www.selenium.dev/documentation/webdriver/bidi/