### PR TITLE
PLATUI-3807 showing examples of some of the refactors I proposed

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,9 @@ object Dependencies {
     "com.typesafe.scala-logging" %% "scala-logging"   % "3.9.5",
     "com.vladsch.flexmark"        % "flexmark-all"    % "0.64.8",
     "org.scalatest"              %% "scalatest"       % "3.2.19",
-    "org.seleniumhq.selenium"     % "selenium-java"   % "4.33.0"
+    "org.seleniumhq.selenium"     % "selenium-java"   % "4.33.0",
+    "org.scalamock"              %% "scalamock"       % "7.5.3"  % Test,
+    "org.wiremock"                % "wiremock"        % "3.13.2" % Test,
+    "com.lihaoyi"                %% "os-lib"          % "0.11.6" % Test
   )
 }

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/DriverFactory.scala
@@ -36,7 +36,7 @@ class DriverFactory extends LazyLogging {
   private val chromeBrowserVersion  = TestRunnerConfig.browserChromeVersion
 
   def initialise(): WebDriver =
-    sourceBrowserBinariesFromArtifactory {
+    SourceBrowserBinariesFromArtifactory {
       TestRunnerConfig.browserType match {
         case Some("chrome")  => new ChromeDriver(chromeOptions())
         case Some("edge")    => new EdgeDriver(edgeOptions())
@@ -45,113 +45,6 @@ class DriverFactory extends LazyLogging {
         case None            => throw DriverFactoryException("System property 'browser' is required but was not defined.")
       }
     }
-
-  private def sourceBrowserBinariesFromArtifactory(initWebDriver: => WebDriver): WebDriver = {
-    if (!TestRunnerConfig.downloadBrowsersFromArtifactory) {
-      logger.info("Artifactory download disabled - using default browser binary sources")
-      return initWebDriver
-    }
-
-    val userHasSetMirrorUrls = TestRunnerConfig.browserType match {
-      case Some("chrome")  =>
-        sys.props.contains("SE_CHROME_MIRROR_URL") ||
-        sys.props.contains("SE_CHROMEDRIVER_MIRROR_URL") ||
-        sys.env.contains("SE_CHROME_MIRROR_URL") ||
-        sys.env.contains("SE_CHROMEDRIVER_MIRROR_URL")
-      case Some("firefox") =>
-        sys.props.contains("SE_FIREFOX_MIRROR_URL") ||
-        sys.props.contains("SE_GECKODRIVER_MIRROR_URL") ||
-        sys.env.contains("SE_FIREFOX_MIRROR_URL") ||
-        sys.env.contains("SE_GECKODRIVER_MIRROR_URL")
-      case Some("edge")    =>
-        sys.props.contains("SE_MSEDGE_MIRROR_URL") ||
-        sys.props.contains("SE_MSEDGEDRIVER_MIRROR_URL") ||
-        sys.env.contains("SE_MSEDGE_MIRROR_URL") ||
-        sys.env.contains("SE_MSEDGEDRIVER_MIRROR_URL")
-      case _               => false
-    }
-
-    if (userHasSetMirrorUrls) {
-      logger.info(
-        "User has already configured browser-specific mirror URLs via system properties - skipping Artifactory configuration"
-      )
-      return initWebDriver
-    }
-
-    val artifactoryBaseUrl = TestRunnerConfig.artifactoryBaseUrl
-
-    if (!isArtifactoryHealthy(artifactoryBaseUrl)) {
-      val errorMessage =
-        """ERROR: Artefactory unreachable. Are you connected to VPN? Make sure your VPN connection is active""".stripMargin
-
-      logger.error(errorMessage)
-      throw DriverFactoryException("Artifactory unreachable. Are you connected to VPN?")
-    }
-
-    val properties = TestRunnerConfig.browserType match {
-      case Some("chrome")  =>
-        Map(
-          "SE_CHROME_MIRROR_URL"       -> s"$artifactoryBaseUrl/chrome-browser/",
-          "SE_CHROMEDRIVER_MIRROR_URL" -> s"$artifactoryBaseUrl/chrome-browser/"
-        )
-      case Some("firefox") =>
-        Map(
-          "SE_FIREFOX_MIRROR_URL"     -> s"$artifactoryBaseUrl/firefox-browser/",
-          "SE_GECKODRIVER_MIRROR_URL" -> s"$artifactoryBaseUrl/firefox-browser/"
-        )
-      case Some("edge")    =>
-        Map(
-          "SE_MSEDGE_MIRROR_URL"       -> s"$artifactoryBaseUrl/edge-browser/",
-          "SE_MSEDGEDRIVER_MIRROR_URL" -> s"$artifactoryBaseUrl/edge-driver/"
-        )
-      case _               =>
-        Map(
-          "SE_CHROME_MIRROR_URL"       -> s"$artifactoryBaseUrl/chrome-browser/",
-          "SE_CHROMEDRIVER_MIRROR_URL" -> s"$artifactoryBaseUrl/chrome-browser/"
-        )
-    }
-
-    logger.info(s"Configuring Artifactory mirror URLs:")
-    properties.foreach { case (key, value) =>
-      logger.info(s"  $key -> $value")
-    }
-
-    try {
-      properties.foreach { case (key, value) =>
-        System.setProperty(key, value)
-      }
-      initWebDriver
-    } finally {
-      properties.keys.foreach(System.clearProperty)
-      logger.debug("Cleared Artifactory mirror URL system properties")
-    }
-  }
-
-  private def isArtifactoryHealthy(artifactoryBaseUrl: String): Boolean = {
-    val healthcheck = s"$artifactoryBaseUrl/api/system/ping"
-    logger.info(s"Checking Artifactory connectivity: $healthcheck")
-
-    val isReachable = {
-      val conn = new java.net.URL(healthcheck).openConnection().asInstanceOf[java.net.HttpURLConnection]
-      conn.setConnectTimeout(1000)
-      try {
-        conn.getResponseCode
-        true
-      } catch {
-        case _: java.net.SocketTimeoutException => false
-        case _: java.net.UnknownHostException   => false
-        case _: java.io.IOException             => false
-      }
-    }
-
-    if (!isReachable) {
-      logger.warn(s"$healthcheck is not reachable")
-    } else {
-      logger.info("Artifactory is reachable. Proceeding with driver initialization.")
-    }
-
-    isReachable
-  }
 
   private[webdriver] def chromeOptions(): ChromeOptions = {
     val options: ChromeOptions = new ChromeOptions

--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/SourceBrowserBinariesFromArtifactory.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/SourceBrowserBinariesFromArtifactory.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import com.typesafe.scalalogging.LazyLogging
+import org.openqa.selenium.WebDriver
+import uk.gov.hmrc.uitestrunner.config.TestRunnerConfig
+
+object SourceBrowserBinariesFromArtifactory extends LazyLogging {
+  def apply(initWebDriver: => WebDriver): WebDriver = {
+    val artifactoryBaseUrl = TestRunnerConfig.artifactoryBaseUrl
+
+    val propertiesToOverride = Seq(
+      "SE_CHROME_MIRROR_URL"       -> s"$artifactoryBaseUrl/chrome-browser/",
+      "SE_CHROMEDRIVER_MIRROR_URL" -> s"$artifactoryBaseUrl/chrome-browser/",
+      "SE_FIREFOX_MIRROR_URL"      -> s"$artifactoryBaseUrl/firefox-browser/",
+      "SE_GECKODRIVER_MIRROR_URL"  -> s"$artifactoryBaseUrl/firefox-browser/",
+      "SE_MSEDGE_MIRROR_URL"       -> s"$artifactoryBaseUrl/edge-browser/",
+      "SE_MSEDGEDRIVER_MIRROR_URL" -> s"$artifactoryBaseUrl/edge-driver/"
+    ).filterNot { case (key, _) =>
+      sys.env.contains(key) || sys.props.contains(key)
+    }
+
+    if (!TestRunnerConfig.downloadBrowsersFromArtifactory || propertiesToOverride.isEmpty) {
+      logger.info("Using default external or environment defined sources for browser binaries")
+      return initWebDriver
+    }
+
+    logger.info(s"Configuring selenium to download any needed browser binaries from $artifactoryBaseUrl")
+
+    // because selenium does not fail fast enough when it's unavailable
+    if (isUnavailable(s"$artifactoryBaseUrl/api/system/ping")) {
+      throw DriverFactoryException(s"Artifactory unreachable. Are you connected to VPN? ($artifactoryBaseUrl)")
+    }
+
+    logger.info(s"Temporarily overriding ${propertiesToOverride.map(_._1).mkString(", ")}")
+    try {
+      sys.props.addAll(propertiesToOverride)
+      initWebDriver
+    } finally
+      propertiesToOverride.foreach { case (key, _) =>
+        sys.props.remove(key)
+      }
+  }
+
+  private def isUnavailable(healthcheck: String): Boolean = {
+    val conn = new java.net.URL(healthcheck).openConnection().asInstanceOf[java.net.HttpURLConnection]
+    conn.setConnectTimeout(1000)
+    try {
+      conn.getResponseCode
+      false
+    } catch {
+      case _: java.net.SocketTimeoutException => true
+      case _: java.net.UnknownHostException   => true
+      case _: java.io.IOException             => true
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/helpers/package.scala
+++ b/src/test/scala/uk/gov/hmrc/helpers/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc
+
+package object helpers {
+  def withSystemProperties[T](properties: (String, String)*)(block: => T): T = {
+    val originalValues = properties.map { case (key, _) => key -> sys.props.get(key) }
+    try {
+      properties.foreach { case (key, value) => sys.props.update(key, value) }
+      block
+    } finally
+      originalValues.foreach {
+        case (key, Some(value)) => sys.props.update(key, value)
+        case (key, None)        => sys.props.remove(key)
+      }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/integration/BrowserIntegrationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/integration/BrowserIntegrationSpec.scala
@@ -16,12 +16,16 @@
 
 package uk.gov.hmrc.integration
 
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.typesafe.config.ConfigFactory
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.firefox.FirefoxDriver
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.helpers.withSystemProperties
 import uk.gov.hmrc.selenium.webdriver.{Browser, Driver}
 
 class BrowserIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAfterEach with Browser {
@@ -71,23 +75,47 @@ class BrowserIntegrationSpec extends AnyWordSpec with Matchers with BeforeAndAft
       quitBrowser()
     }
 
-    "respect user-configured SE_CHROME_MIRROR_URL and skip Artifactory configuration" in {
-      System.setProperty("browser", "chrome")
-      System.setProperty("browser.version", "136")
-      System.setProperty("browser.option.downloadFromArtifactory", "true")
-      System.setProperty("ARTIFACTORY_URI", "https://unreachable-artifactory.invalid")
-      System.setProperty("SE_CHROME_MIRROR_URL", "https://artefacts.tax.service.gov.uk/artifactory/chrome-browser/")
-      System.setProperty(
-        "SE_CHROMEDRIVER_MIRROR_URL",
-        "https://artefacts.tax.service.gov.uk/artifactory/chrome-browser/"
-      )
-      ConfigFactory.invalidateCaches()
+    "source browser binaries from artifactory" in {
+      val fakeArtifactory = new WireMockServer(options().dynamicPort())
 
-      startBrowser()
+      // this is needed because we fail early if artifactory is not
+      // enabled, so our test won't verify that selenium is trying
+      // to use artifactory if this request fails.
+      fakeArtifactory
+        .stubFor(
+          get("/api/system/ping")
+            .willReturn(aResponse().withStatus(200))
+        )
 
-      Driver.instance.asInstanceOf[ChromeDriver].getSessionId shouldNot be(null)
+      fakeArtifactory
+        .stubFor(
+          get("/chrome-browser/known-good-versions-with-downloads.json")
+            .willReturn(aResponse().withStatus(503))
+        )
 
-      quitBrowser()
+      try {
+        fakeArtifactory.start()
+
+        withSystemProperties(
+          "browser"                                -> "chrome",
+          "browser.version"                        -> "136",
+          "ARTIFACTORY_URI"                        -> fakeArtifactory.baseUrl(),
+          "browser.option.downloadFromArtifactory" -> "true",
+          // without the following it didn't always seem to make a request to artifactory so
+          // the tests could be flakey - there wouldn't always be an exception intercepted
+          "SE_CACHE_PATH"                          -> os.temp.dir(deleteOnExit = true).toString
+        ) {
+          ConfigFactory.invalidateCaches()
+
+          intercept[Exception] {
+            startBrowser()
+          }
+        }
+
+        fakeArtifactory
+          .verify(1, getRequestedFor(urlEqualTo("/chrome-browser/known-good-versions-with-downloads.json")))
+      } finally
+        fakeArtifactory.stop()
     }
 
     "start and quit Firefox browser with Artifactory enabled" in {

--- a/src/test/scala/uk/gov/hmrc/selenium/webdriver/SourceBrowserBinariesFromArtifactorySpec.scala
+++ b/src/test/scala/uk/gov/hmrc/selenium/webdriver/SourceBrowserBinariesFromArtifactorySpec.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.selenium.webdriver
+
+import org.openqa.selenium.WebDriver
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.uitestrunner.config.TestRunnerConfig
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.helpers.withSystemProperties
+
+class SourceBrowserBinariesFromArtifactorySpec extends AnyWordSpec with Matchers with MockFactory {
+
+  "SourceBrowserBinariesFromArtifactory" should {
+    val artifactoryBaseUrl = TestRunnerConfig.artifactoryBaseUrl
+
+    "override system properties that control where selenium gets browser binaries from temporarily" in {
+      SourceBrowserBinariesFromArtifactory {
+        sys.props.get("SE_CHROME_MIRROR_URL")       should be(Some(s"$artifactoryBaseUrl/chrome-browser/"))
+        sys.props.get("SE_CHROMEDRIVER_MIRROR_URL") should be(Some(s"$artifactoryBaseUrl/chrome-browser/"))
+        sys.props.get("SE_FIREFOX_MIRROR_URL")      should be(Some(s"$artifactoryBaseUrl/firefox-browser/"))
+        sys.props.get("SE_GECKODRIVER_MIRROR_URL")  should be(Some(s"$artifactoryBaseUrl/firefox-browser/"))
+        sys.props.get("SE_MSEDGE_MIRROR_URL")       should be(Some(s"$artifactoryBaseUrl/edge-browser/"))
+        sys.props.get("SE_MSEDGEDRIVER_MIRROR_URL") should be(Some(s"$artifactoryBaseUrl/edge-driver/"))
+        stub[WebDriver]
+      }
+      sys.props.get("SE_CHROME_MIRROR_URL")       should be(None)
+      sys.props.get("SE_CHROMEDRIVER_MIRROR_URL") should be(None)
+      sys.props.get("SE_FIREFOX_MIRROR_URL")      should be(None)
+      sys.props.get("SE_GECKODRIVER_MIRROR_URL")  should be(None)
+      sys.props.get("SE_MSEDGE_MIRROR_URL")       should be(None)
+      sys.props.get("SE_MSEDGEDRIVER_MIRROR_URL") should be(None)
+    }
+
+    "not override system properties already set by the user" in {
+      withSystemProperties(
+        "SE_CHROME_MIRROR_URL"       -> "???",
+        "SE_CHROMEDRIVER_MIRROR_URL" -> "???"
+      ) {
+        SourceBrowserBinariesFromArtifactory {
+          sys.props.get("SE_CHROME_MIRROR_URL")       should be(Some(s"???"))
+          sys.props.get("SE_CHROMEDRIVER_MIRROR_URL") should be(Some(s"???"))
+          sys.props.get("SE_FIREFOX_MIRROR_URL")      should be(Some(s"$artifactoryBaseUrl/firefox-browser/"))
+          sys.props.get("SE_GECKODRIVER_MIRROR_URL")  should be(Some(s"$artifactoryBaseUrl/firefox-browser/"))
+          sys.props.get("SE_MSEDGE_MIRROR_URL")       should be(Some(s"$artifactoryBaseUrl/edge-browser/"))
+          sys.props.get("SE_MSEDGEDRIVER_MIRROR_URL") should be(Some(s"$artifactoryBaseUrl/edge-driver/"))
+          stub[WebDriver]
+        }
+        sys.props.get("SE_CHROME_MIRROR_URL")       should be(Some("???"))
+        sys.props.get("SE_CHROMEDRIVER_MIRROR_URL") should be(Some("???"))
+        sys.props.get("SE_FIREFOX_MIRROR_URL")      should be(None)
+        sys.props.get("SE_GECKODRIVER_MIRROR_URL")  should be(None)
+        sys.props.get("SE_MSEDGE_MIRROR_URL")       should be(None)
+        sys.props.get("SE_MSEDGEDRIVER_MIRROR_URL") should be(None)
+      }
+    }
+
+    "throw an exception if artifactory is unavailable and get base url from ARTIFACTORY_URI" in {
+      withSystemProperties("ARTIFACTORY_URI" -> "http://localhost") {
+        val exception = intercept[Exception] {
+          SourceBrowserBinariesFromArtifactory {
+            stub[WebDriver]
+          }
+        }
+        exception.getMessage should be("Artifactory unreachable. Are you connected to VPN? (http://localhost)")
+      }
+    }
+
+    "be able to be disabled" in {
+      withSystemProperties("browser.option.downloadFromArtifactory" -> "false") {
+        SourceBrowserBinariesFromArtifactory {
+          sys.props.get("SE_CHROME_MIRROR_URL")       should be(None)
+          sys.props.get("SE_CHROMEDRIVER_MIRROR_URL") should be(None)
+          sys.props.get("SE_FIREFOX_MIRROR_URL")      should be(None)
+          sys.props.get("SE_GECKODRIVER_MIRROR_URL")  should be(None)
+          sys.props.get("SE_MSEDGE_MIRROR_URL")       should be(None)
+          sys.props.get("SE_MSEDGEDRIVER_MIRROR_URL") should be(None)
+          stub[WebDriver]
+        }
+      }
+    }
+
+    "skip artifactory availability check when disabled" in {
+      withSystemProperties(
+        "ARTIFACTORY_URI"                        -> "http://localhost",
+        "browser.option.downloadFromArtifactory" -> "false"
+      ) {
+        noException should be thrownBy {
+          SourceBrowserBinariesFromArtifactory {
+            stub[WebDriver]
+          }
+        }
+      }
+    }
+
+    "skip artifactory availability check when everything is overridden" in {
+      withSystemProperties(
+        "ARTIFACTORY_URI"            -> "http://localhost", // which would error if checked
+        "SE_CHROME_MIRROR_URL"       -> "???",
+        "SE_CHROMEDRIVER_MIRROR_URL" -> "???",
+        "SE_FIREFOX_MIRROR_URL"      -> "???",
+        "SE_GECKODRIVER_MIRROR_URL"  -> "???",
+        "SE_MSEDGE_MIRROR_URL"       -> "???",
+        "SE_MSEDGEDRIVER_MIRROR_URL" -> "???"
+      ) {
+        noException should be thrownBy {
+          SourceBrowserBinariesFromArtifactory {
+            stub[WebDriver]
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
was to show some examples of some of the refactors I proposed
- extracted the selenium config overriding to separate file
- made it always set all the config not set by user, not only the ones for the specific browser being used, to simplify the code
- added some test helpers to reduce test boilerplate
- added an example of a test using wiremock to verify that selenium uses the config