### PR TITLE
[ScreenshotOnFailureTryCatch] Add guard around screenshot capture

### DIFF
--- a/src/main/scala/uk/gov/hmrc/selenium/webdriver/ScreenshotOnFailure.scala
+++ b/src/main/scala/uk/gov/hmrc/selenium/webdriver/ScreenshotOnFailure.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.selenium.webdriver
 
+import com.typesafe.scalalogging.LazyLogging
 import org.openqa.selenium.firefox.HasFullPageScreenshot
 import org.openqa.selenium.io.FileHandler.{copy, createDir}
 import org.openqa.selenium.{OutputType, TakesScreenshot}
@@ -23,7 +24,7 @@ import org.scalatest.{Documenting, Outcome, TestSuite, TestSuiteMixin}
 
 import java.io.File
 
-trait ScreenshotOnFailure extends TestSuiteMixin with Documenting { this: TestSuite =>
+trait ScreenshotOnFailure extends TestSuiteMixin with Documenting with LazyLogging { this: TestSuite =>
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
     val testOutcome         = super.withFixture(test)
@@ -32,8 +33,13 @@ trait ScreenshotOnFailure extends TestSuiteMixin with Documenting { this: TestSu
     val screenshotDirectory = "./target/test-reports/html-report/images/screenshots/"
 
     if (testOutcome.isExceptional) {
-      captureScreenshot(screenshotName, screenshotDirectory)
-      markup(s"<img src='images/screenshots/$screenshotName' />")
+      try {
+        captureScreenshot(screenshotName, screenshotDirectory)
+        markup(s"<img src='images/screenshots/$screenshotName' />")
+      } catch {
+        case e: Exception =>
+          logger.error(s"Failed to capture screenshot for test: $testName. Error: ${e.getMessage}")
+      }
     }
 
     testOutcome


### PR DESCRIPTION
**Notes**
- Currently, if the capturing of the screenshot dies it throws an exception which causes the real error from the test to be masked
- this adds a `try` `catch` guard to log out the error for the screenshot capture but without throwing an exception, allowing the true error to return from `withFixture`